### PR TITLE
Add lock around _scraped_data as read/write happens on different threads

### DIFF
--- a/webserver.py
+++ b/webserver.py
@@ -54,7 +54,17 @@ class MyHandler(BaseHTTPRequestHandler):
                 if inst not in _scraped_data.keys():
                     raise ValueError(str(inst) + " not known")
                 try:
-                    ans = "%s(%s)" % (callback, _scraped_data[inst])
+                    def convert_to_string(data):
+                        import collections
+                        if isinstance(data, basestring):
+                            return str(data)
+                        elif isinstance(data, collections.Mapping):
+                            return dict(map(convert_to_string, data.iteritems()))
+                        elif isinstance(data, collections.Iterable):
+                            return type(data)(map(convert_to_string, data))
+                        else:
+                            return str(data)
+                    ans = "%s(%s)" % (callback, convert_to_string(_scraped_data[inst]))
                 except Exception as err:
                     raise ValueError("Unable to convert instrument data to JSON: %s" % err.message)
 

--- a/webserver.py
+++ b/webserver.py
@@ -54,17 +54,7 @@ class MyHandler(BaseHTTPRequestHandler):
                 if inst not in _scraped_data.keys():
                     raise ValueError(str(inst) + " not known")
                 try:
-                    def convert_to_string(data):
-                        import collections
-                        if isinstance(data, basestring):
-                            return str(data)
-                        elif isinstance(data, collections.Mapping):
-                            return dict(map(convert_to_string, data.iteritems()))
-                        elif isinstance(data, collections.Iterable):
-                            return type(data)(map(convert_to_string, data))
-                        else:
-                            return str(data)
-                    ans = "%s(%s)" % (callback, convert_to_string(_scraped_data[inst]))
+                    ans = "%s(%s)" % (callback, json.dumps(_scraped_data[inst]))
                 except Exception as err:
                     raise ValueError("Unable to convert instrument data to JSON: %s" % err.message)
 


### PR DESCRIPTION
I've added a thread lock around read/writes to _scraped_data since the operations happen on different threads. I observed the error reported on PR https://github.com/ISISComputingGroup/JSON_bourne/pull/5 and it no longer occurs so hopefully that's caught the issue.

ISISComputingGroup/IBEX#1750