### PR TITLE
Ticket2807: Overview page occasionally times out

### DIFF
--- a/overview_page/ibexOverview.html
+++ b/overview_page/ibexOverview.html
@@ -63,6 +63,7 @@
         <div class="col-sm-12">
           <div class="well">
 		  <div id = "buttons"></div>
+		  <h5 id = "time" style="color:black" class="text-left">Last Updated: </h5>
         </div>
       </div>
       <div id = "new_window">

--- a/overview_page/ibexOverview.js
+++ b/overview_page/ibexOverview.js
@@ -2,7 +2,7 @@ var PORT = 60000;
 var HOST = "http://dataweb.isis.rl.ac.uk"
 
 var INST_REFRESH = 5000;
-var WALL_DISP_REFRESH = 60000;
+var WALL_DISP_REFRESH = 2 * 60 * 1000;
 var TIMEOUT = 1000;
 
 function refresh_instruments() {
@@ -12,7 +12,7 @@ function refresh_instruments() {
 		data: {"Instrument": "all"},
 		timeout: TIMEOUT,
 		error: function(xhr, status, error){ 
-			window.alert("Error: JSON not read. Error was: " + error);
+			document.getElementById("time").setAttribute("style", "color:red")
 		},
 		success: function(data){ 
 			display_data(data);
@@ -22,7 +22,8 @@ function refresh_instruments() {
 
 function refresh_wall_display() {
 	// Refresh the wall display as it has a memory leak
-	document.getElementById('wall_display').src = document.getElementById('wall_display').src
+	var display = document.getElementById('wall_display');
+	display.src = display.src;
 }
 
 function clearBox(elementID){
@@ -45,10 +46,6 @@ function sortDictionary(o) {
         sorted[a[i]] = o[a[i]];
     }
     return sorted;
-}
-
-function close_window(){
-	clearBox("new_window");
 }
 
 function create_new_window(){
@@ -137,8 +134,11 @@ function display_data(data){
 		newButton.setAttributeNode(blockListStyle);
 
 		document.getElementById("buttons").appendChild(newButton);
-
 	}
+	var time = document.getElementById("time");
+	var date = new Date();
+	time.innerHTML = "Last updated at: " + date.toLocaleTimeString();
+	time.setAttribute("style", "color:black");
 }
 
 var windowWidth = $(window).width();

--- a/overview_page/ibexOverview.js
+++ b/overview_page/ibexOverview.js
@@ -3,7 +3,7 @@ var HOST = "http://dataweb.isis.rl.ac.uk"
 
 var INST_REFRESH = 5000;
 var WALL_DISP_REFRESH = 2 * 60 * 1000;
-var TIMEOUT = 1000;
+var TIMEOUT = 2500;
 
 function refresh_instruments() {
 	$.ajax({

--- a/overview_page/ibexOverview.js
+++ b/overview_page/ibexOverview.js
@@ -14,9 +14,7 @@ function refresh_instruments() {
 		error: function(xhr, status, error){ 
 			document.getElementById("time").setAttribute("style", "color:red")
 		},
-		success: function(data){ 
-			display_data(data);
-		}
+		jsonpCallback: "display_data"
 	});
 }
 

--- a/overview_page/ibexOverview.js
+++ b/overview_page/ibexOverview.js
@@ -1,12 +1,16 @@
 var PORT = 60000;
 var HOST = "http://dataweb.isis.rl.ac.uk"
 
-function refresh() {
+var INST_REFRESH = 5000;
+var WALL_DISP_REFRESH = 60000;
+var TIMEOUT = 1000;
+
+function refresh_instruments() {
 	$.ajax({
 		url: HOST + ":" + PORT + "/",
 		dataType: 'jsonp',
 		data: {"Instrument": "all"},
-		timeout: 1000,
+		timeout: TIMEOUT,
 		error: function(xhr, status, error){ 
 			window.alert("Error: JSON not read. Error was: " + error);
 		},
@@ -14,6 +18,11 @@ function refresh() {
 			display_data(data);
 		}
 	});
+}
+
+function refresh_wall_display() {
+	// Refresh the wall display as it has a memory leak
+	document.getElementById('wall_display').src = document.getElementById('wall_display').src
 }
 
 function clearBox(elementID){
@@ -59,6 +68,7 @@ function create_new_window(){
 function open_wall_display(){
 	create_new_window()
 	var newIframe = document.createElement("iframe");
+	newIframe.setAttribute("id", "wall_display");
 	
 	newIframe.src = "http://epics-jenkins.isis.rl.ac.uk/plugin/jenkinswalldisplay/walldisplay.html?viewName=All&jenkinsUrl=http%3A%2F%2Fepics-jenkins.isis.rl.ac.uk%2F"
 	newIframe.height = String(windowHeight*2/5)+"px"
@@ -131,12 +141,13 @@ function display_data(data){
 	}
 }
 
-$(document).ready(refresh());
-
 var windowWidth = $(window).width();
 var windowHeight = $(window).height();
 var buttonHeight = $(window).height();
 
 open_wall_display();
 
-setInterval(refresh, 5000);
+$(document).ready(refresh_instruments());
+
+setInterval(refresh_instruments, INST_REFRESH);
+setInterval(refresh_wall_display, WALL_DISP_REFRESH);


### PR DESCRIPTION
See https://github.com/ISISComputingGroup/IBEX/issues/2807

I'm still not 100% what's causing this:
* Despite the error being produced in the JSON bourne communication code the website is fine when the wall display part is removed.
* It seems to get worse over time, which relates to the comment @KathrynBaker made on the original ticket. 
* It appears to be more stable in Chrome

There is a known memory leak (https://issues.jenkins-ci.org/browse/JENKINS-45064) which I suspect may have something to do with it. What I've done is to:
* Remove the modal error box, replaced with a timer that gives when the data was last received and goes red when the data is too old
* Refresh the wall display part periodically. This will clear it's memory and seems to reduce the issue but is annoying if done too often.
