### PR TITLE
Ticket2777 JSON_Bourne instrument status ordering of Groups/Blocks

### DIFF
--- a/block_utils.py
+++ b/block_utils.py
@@ -1,6 +1,8 @@
 from __future__ import unicode_literals
 import logging
 
+from collections import OrderedDict
+
 logger = logging.getLogger('JSON_bourne')
 
 def shorten_title(title):
@@ -62,7 +64,7 @@ def format_blocks(blocks):
     Returns: A JSON dictionary of block names to block descriptions.
 
     """
-    blocks_formatted = {}
+    blocks_formatted = OrderedDict()
     for name, block in blocks.items():
         blocks_formatted[name] = block.get_description()
 

--- a/block_utils.py
+++ b/block_utils.py
@@ -56,12 +56,12 @@ def set_rc_values_for_blocks(blocks, run_control_pvs):
 
 def format_blocks(blocks):
     """
-    Converts a list of block objects into JSON.
+    Converts a dictionary of blocks in the form of {name: Block} to a dictionary of {name: dict_describing_block}.
 
     Args:
         blocks: A dictionary of block names to block objects.
 
-    Returns: A JSON dictionary of block names to block descriptions.
+    Returns: A dictionary of block names to block descriptions.
 
     """
     blocks_formatted = OrderedDict()

--- a/external_webpage/instrument_information_collator.py
+++ b/external_webpage/instrument_information_collator.py
@@ -174,7 +174,6 @@ class InstrumentInformationCollator:
         Returns: JSON of the instrument's configuration and status.
 
         """
-
         instrument_config = InstrumentConfig(self.reader.read_config())
 
         try:
@@ -205,7 +204,7 @@ class InstrumentInformationCollator:
             block.set_visibility(instrument_config.block_is_visible(block_name))
 
         blocks_all_formatted = format_blocks(blocks)
-        groups = {}
+        groups = OrderedDict()
         for group in instrument_config.groups:
             blocks = OrderedDict()
             for block in group["blocks"]:

--- a/external_webpage/instrument_information_collator.py
+++ b/external_webpage/instrument_information_collator.py
@@ -28,6 +28,28 @@ from collections import OrderedDict
 logger = logging.getLogger('JSON_bourne')
 
 
+def create_groups_dictionary(archive_blocks, instrument_config):
+    """
+    Populate groups with block information from the archive server.
+    Args:
+        archive_blocks (dict[str, block.Block]): Block information from the archive server.
+        instrument_config (InstrumentConfig): Instrument configurations from the block server.
+
+    Returns:
+        groups (dict): All groups and their associated blocks.
+
+    """
+    blocks_all_formatted = format_blocks(archive_blocks)
+    groups = OrderedDict()
+    for group in instrument_config.groups:
+        blocks = OrderedDict()
+        for block in group["blocks"]:
+            if block in blocks_all_formatted.keys():
+                blocks[block] = blocks_all_formatted[block]
+        groups[group["name"]] = blocks
+    return groups
+
+
 class InstrumentConfig(object):
     """
     The instrument configuration.
@@ -203,14 +225,7 @@ class InstrumentInformationCollator:
         for block_name, block in blocks.items():
             block.set_visibility(instrument_config.block_is_visible(block_name))
 
-        blocks_all_formatted = format_blocks(blocks)
-        groups = OrderedDict()
-        for group in instrument_config.groups:
-            blocks = OrderedDict()
-            for block in group["blocks"]:
-                if block in blocks_all_formatted.keys():
-                    blocks[block] = blocks_all_formatted[block]
-            groups[group["name"]] = blocks
+        groups = create_groups_dictionary(blocks, instrument_config)
 
         return {
             "config_name": instrument_config.name,

--- a/external_webpage/instrument_information_collator.py
+++ b/external_webpage/instrument_information_collator.py
@@ -23,6 +23,8 @@ from block_utils import (format_blocks, set_rc_values_for_blocks)
 from external_webpage.data_source_reader import DataSourceReader
 from external_webpage.web_page_parser import WebPageParser
 
+from collections import OrderedDict
+
 logger = logging.getLogger('JSON_bourne')
 
 
@@ -41,7 +43,7 @@ class InstrumentConfig(object):
         self.groups = self._config["groups"]
         self.name = self._config["name"]
 
-        self.blocks = {}
+        self.blocks = OrderedDict()
         for block in self._config["blocks"]:
             self.blocks[block["name"]] = block
 
@@ -205,7 +207,7 @@ class InstrumentInformationCollator:
         blocks_all_formatted = format_blocks(blocks)
         groups = {}
         for group in instrument_config.groups:
-            blocks = {}
+            blocks = OrderedDict()
             for block in group["blocks"]:
                 if block in blocks_all_formatted.keys():
                     blocks[block] = blocks_all_formatted[block]

--- a/external_webpage/instrument_information_collator.py
+++ b/external_webpage/instrument_information_collator.py
@@ -36,7 +36,7 @@ def create_groups_dictionary(archive_blocks, instrument_config):
         instrument_config (InstrumentConfig): Instrument configurations from the block server.
 
     Returns:
-        groups (dict): All groups and their associated blocks.
+        groups (dict[str, dict[str, dict]]): All groups and their associated blocks.
 
     """
     blocks_all_formatted = format_blocks(archive_blocks)

--- a/external_webpage/instrument_scapper.py
+++ b/external_webpage/instrument_scapper.py
@@ -9,7 +9,7 @@ scraped_data = {}
 scraped_data_lock = RLock()
 logger = logging.getLogger('JSON_bourne')
 
-WAIT_BETWEEN_UPDATES = 3
+WAIT_BETWEEN_UPDATES = 5
 WAIT_BETWEEN_FAILED_UPDATES = 60
 RETRIES_BETWEEN_LOGS = 60
 

--- a/external_webpage/web_page_parser.py
+++ b/external_webpage/web_page_parser.py
@@ -24,6 +24,8 @@ import re
 from block import Block
 from block_utils import shorten_title
 
+from collections import OrderedDict
+
 logger = logging.getLogger('JSON_bourne')
 
 
@@ -58,7 +60,7 @@ class WebPageParser(object):
         """
 
         try:
-            blocks = {}
+            blocks = OrderedDict()
             channels = info_page_as_json["Channels"]
         except (KeyError, TypeError):
             raise BlocksParseError("There is no json object for channels")

--- a/external_webpage/web_scrapper_manager.py
+++ b/external_webpage/web_scrapper_manager.py
@@ -53,7 +53,7 @@ class InstList(object):
         Returns: list of instruments with their host names
         """
 
-        inst_list = {"ME":"localhost"}
+        inst_list = {}
         try:
 
             raw = self._caget_fn(INST_LIST_PV, as_string=True)

--- a/external_webpage/web_scrapper_manager.py
+++ b/external_webpage/web_scrapper_manager.py
@@ -53,7 +53,7 @@ class InstList(object):
         Returns: list of instruments with their host names
         """
 
-        inst_list = {}
+        inst_list = {"ME":"localhost"}
         try:
 
             raw = self._caget_fn(INST_LIST_PV, as_string=True)

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -1,5 +1,5 @@
 var PORT = 60000;
-var HOST = "http://dataweb.isis.rl.ac.uk"
+var HOST = "http://localhost"
 
 var instrument = getURLParameter("Instrument");
 var nodeInstTitle = document.createElement("H2");

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -1,5 +1,5 @@
 var PORT = 60000;
-var HOST = "http://localhost"
+var HOST = "dataweb.isis.rl.ac.uk"
 
 var instrument = getURLParameter("Instrument");
 var nodeInstTitle = document.createElement("H2");

--- a/tests/test_block_utils.py
+++ b/tests/test_block_utils.py
@@ -7,6 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 import unittest
+from mock import MagicMock
 from block import Block
 from block_utils import (format_blocks, set_rc_values_for_blocks, shorten_title, format_block_value)
 
@@ -114,6 +115,23 @@ class TestBlockUtils(unittest.TestCase):
 
         #Assert
         self.assertEquals(formatted_blocks, expected_result)
+
+    def test_GIVEN_dict_of_ordered_blocks_WHEN_formatted_blocks_called_THEN_return_same_block_order(self):
+        #Arrange
+        test_blocks = {"Block 1": MagicMock(),
+                       "Block 2": MagicMock(),
+                       "Block 3": MagicMock()}
+
+        expected_order_blocks = {"Block 1": MagicMock(),
+                                 "Block 2": MagicMock(),
+                                 "Block 3": MagicMock()}
+
+        #Act
+        formatted_blocks = format_blocks(test_blocks)
+
+        #Assert
+        self.assertListEqual(expected_order_blocks.keys(), formatted_blocks.keys())
+
 
     def test_shorten_title_for_default_case(self):
         #Arrange

--- a/tests/test_instrument_information_collator.py
+++ b/tests/test_instrument_information_collator.py
@@ -1,0 +1,71 @@
+import unittest
+
+from mock import Mock
+from external_webpage.instrument_information_collator import create_groups_dictionary
+
+
+class TestInstrumentInformationCollator(unittest.TestCase):
+
+    def test_GIVEN_instrument_config_with_no_groups_WHEN_create_groups_dictionary_called_THEN_return_empty_dict(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = []
+        result = create_groups_dictionary({}, instrument_config)
+
+        self.assertDictEqual(result, {})
+
+    def test_GIVEN_instrument_config_with_groups_and_no_blocks_WHEN_create_groups_dictionary_called_THEN_return_group_without_blocks(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = [{'name': 'test_group', 'blocks': []}]
+        result = create_groups_dictionary({}, instrument_config)
+
+        self.assertDictEqual(result, {'test_group': {}})
+
+    def test_GIVEN_instrument_config_with_3_known_groups_WHEN_create_groups_dictionary_called_THEN_return_5_groups(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = [{'name': 'test_group_1', 'blocks': []},
+                                    {'name': 'test_group_2', 'blocks': []},
+                                    {'name': 'test_group_3', 'blocks': []}]
+        result = create_groups_dictionary({}, instrument_config)
+
+        self.assertEqual(len(result.keys()), 3)
+
+    def test_GIVEN_block_in_archive_blocks_and_not_instrument_config_WHEN_create_groups_dictionary_called_THEN_return_no_blocks(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = []
+        archive_block = {'test_block': Mock()}
+        result = create_groups_dictionary(archive_block, instrument_config)
+
+        self.assertNotIn('test_block', result)
+
+
+    def test_GIVEN_block_in_instrument_config_and_not_archive_blocks_WHEN_create_groups_dictionary_called_THEN_return_no_blocks(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = [{'name': 'test_group', 'blocks': ['test_block']}]
+        result = create_groups_dictionary({}, instrument_config)
+
+        self.assertNotIn('test_block', result)
+
+
+    def test_GIVEN_block_in_both_instrument_config_and_archive_blocks_WHEN_create_groups_dictionary_called_THEN_return_group_from_instrument_config_with_archive_blocks_data(self):
+
+        instrument_config = Mock()
+        instrument_config.groups = [{'name': 'test_group', 'blocks': ['test_block']}]
+        archive_block = {'test_block': Mock()}
+        result = create_groups_dictionary(archive_block, instrument_config)
+
+        self.assertIn('test_block', result['test_group'])
+
+    def test_GIVEN_ordered_groups_WHEN_create_groups_dictionary_called_THEN_return_same_ordered_groups(self):
+        instrument_config = Mock()
+        instrument_config.groups = [{'name': 'test_group_1', 'blocks': []},
+                                    {'name': 'test_group_2', 'blocks': []},
+                                    {'name': 'test_group_3', 'blocks': []}]
+        result = create_groups_dictionary({}, instrument_config)
+
+
+        self.assertTrue(result.keys(), [group['name'] for group in instrument_config.groups])

--- a/tests/test_instrument_information_collator.py
+++ b/tests/test_instrument_information_collator.py
@@ -22,7 +22,7 @@ class TestInstrumentInformationCollator(unittest.TestCase):
 
         self.assertDictEqual(result, {'test_group': {}})
 
-    def test_GIVEN_instrument_config_with_3_known_groups_WHEN_create_groups_dictionary_called_THEN_return_5_groups(self):
+    def test_GIVEN_instrument_config_with_3_known_groups_WHEN_create_groups_dictionary_called_THEN_return_3_groups(self):
 
         instrument_config = Mock()
         instrument_config.groups = [{'name': 'test_group_1', 'blocks': []},
@@ -67,7 +67,7 @@ class TestInstrumentInformationCollator(unittest.TestCase):
                                     {'name': 'test_group_3', 'blocks': []}]
         result = create_groups_dictionary({}, instrument_config)
 
-        self.assertTrue(result.keys(), [group['name'] for group in instrument_config.groups])
+        self.assertListEqual(result.keys(), [group['name'] for group in instrument_config.groups])
 
 
 if __name__ == '__main__':

--- a/tests/test_instrument_information_collator.py
+++ b/tests/test_instrument_information_collator.py
@@ -67,5 +67,8 @@ class TestInstrumentInformationCollator(unittest.TestCase):
                                     {'name': 'test_group_3', 'blocks': []}]
         result = create_groups_dictionary({}, instrument_config)
 
-
         self.assertTrue(result.keys(), [group['name'] for group in instrument_config.groups])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
### Description of work

The ordering of the groups and blocks displayed on the web frontend were in the incorrect ordering (with respect to the IBEX GUI). The correct ordering existed on the block server and archive engine, however the types used for storing this data in the JSON_bourne server did not preserve this ordering. To fix this I ensured ordered dictionaries are used to maintain this. I subsequently refactored slightly and created unit tests for the function that collates these JSON structures.

### Ticket

Fixes https://github.com/ISISComputingGroup/IBEX/issues/2777

### Acceptance criteria

The expected ordering of the groups and their associated blocks is now preserved on the Instrument Status web frontend. Unit tests have been implemented to ensure this ordering is maintained if the code changes at a later date.

### Unit tests

'test_instrument_infomation_collator.py' now contains a number of tests to ensure the expected behaviour is observed.

### System tests

None.

### Documentation

Docstring for the 'create_groups_dictionary' created. Also updated [https://github.com/ISISComputingGroup/ibex_developers_manual/wiki/Python-conventions](Python conventions) wiki to include information for other dev's that PyCharm can specify and detect types in the docstring of a function (useful feature).

---

#### Code Review

- [ ] Is the code of an acceptable quality?
- [ ] Do the changes function as described and is it robust?
- [ ] Have the changes been documented in the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev)?

### Final Steps
- [ ] Reviewer has moved the [release notes](https://github.com/ISISComputingGroup/IBEX/wiki/ReleaseNotes_Dev) entry for this ticket in the "Changes merged into master" section

