### PR TITLE
Fix JSON bourne build

### DIFF
--- a/build/update_genie_python.bat
+++ b/build/update_genie_python.bat
@@ -3,8 +3,8 @@ setlocal
 REM It only takes two or three minutes to do a full install, so for simplicity we do that.
 REM it is installed using xcopy /d, so if it hasn't changed then it doesn't do anything.
 
-set PYTHON_KITS_PATH=p:\Kits$\CompGroup\ICP\genie_python\
-set PYTHON_INSTALL_DIR=C:\Instrument\Apps\Python
+set PYTHON_KITS_PATH=p:\Kits$\CompGroup\ICP\genie_python_3\
+set PYTHON_INSTALL_DIR=C:\Instrument\Apps\Python3
 
 @echo Updating genie_python
 

--- a/build/update_genie_python.bat
+++ b/build/update_genie_python.bat
@@ -1,5 +1,5 @@
 setlocal
-@echo off
+@echo on
 REM It only takes two or three minutes to do a full install, so for simplicity we do that.
 REM it is installed using xcopy /d, so if it hasn't changed then it doesn't do anything.
 

--- a/build/update_genie_python.bat
+++ b/build/update_genie_python.bat
@@ -1,5 +1,5 @@
 setlocal
-@echo on
+@echo off
 REM It only takes two or three minutes to do a full install, so for simplicity we do that.
 REM it is installed using xcopy /d, so if it hasn't changed then it doesn't do anything.
 


### PR DESCRIPTION
JSON bourne now runs on Python 3 so we need to update the version of python it installs.

To test:
* Confirm that the latest builds of this branch work (http://epics-jenkins.isis.rl.ac.uk/job/json_bourne/)

Once done, stop jenkins from looking at this branch (http://epics-jenkins.isis.rl.ac.uk/job/json_bourne/configure)