### PR TITLE
Display variable parameters on top of list, Remove duplicates and empty blocks

### DIFF
--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -12,8 +12,6 @@ dictInstPV = {
     RUNSTATE: 'Run Status',
     RUNNUMBER: 'Run Number',
     _RBNUMBER: 'RB Number',
-    _USERNAME: 'User(s)',
-    TITLE: 'Title',
     TITLEDISP: 'Show Title',
     STARTTIME: 'Start Time',
     RUNDURATION: 'Total Run Time',
@@ -22,22 +20,16 @@ dictInstPV = {
     GOODFRAMES_PD: 'Good Frames (Period)',
     RAWFRAMES: 'Raw Frames (Total)',
     RAWFRAMES_PD: 'Raw Frames (Period)',
-    PERIOD: 'Current Period',
-    NUMPERIODS: 'Number of Periods',
     PERIODSEQ: 'Period Sequence',
-    BEAMCURRENT: 'Beam Current',
-    TOTALUAMPS: 'Total Uamps',
     COUNTRATE: 'Count Rate',
     DAEMEMORYUSED: 'DAE Memory Used',
     TOTALCOUNTS: 'Total DAE Counts',
     DAETIMINGSOURCE: 'DAE Timing Source',
-    MONITORCOUNTS: 'Monitor Counts',
     MONITORSPECTRUM: 'Monitor Spectrum',
     MONITORFROM: 'Monitor From',
     MONITORTO: 'Monitor To',
     NUMTIMECHANNELS: 'Number of Time Channels',
     NUMSPECTRA: 'Number of Spectra',
-	SHUTTER: 'Shutter Status',
 	SIM_MODE: 'DAE Simulation mode'
 };
 
@@ -386,7 +378,7 @@ function displayOneBlock(node, block, blockName, linkGraph) {
 }
 
 /**
- * Adds html elements for a list of block objects to a given node.
+ * Adds html elements from a list of block objects to a given node.
  *
  * @param node The parent node.
  * @param blocks The list of block objects to display.
@@ -394,12 +386,21 @@ function displayOneBlock(node, block, blockName, linkGraph) {
  * @return The updated node.
  */
 function getDisplayBlocks(node, blocks, linkGraph) {
-    var ignore_pvs = ["1:1:VALUE", "2:1:VALUE", "3:1:VALUE", "1:2:VALUE", "2:2:VALUE", "3:2:VALUE", "BANNER:RIGHT:VALUE", "BANNER:LEFT:VALUE", "BANNER:MIDDLE:VALUE"];
+    ignore_pvs = [
+        "1:1:VALUE", "2:1:VALUE", "3:1:VALUE", "1:2:VALUE", "2:2:VALUE", "3:2:VALUE", "BANNER:RIGHT:VALUE", "BANNER:LEFT:VALUE", "BANNER:MIDDLE:VALUE", 
+        "BEAMCURRENT", "PERIOD", "NUMPERIODS", "TOTALUAMPS", "MONITORCOUNTS", "SHUTTER", "_USERNAME", "TITLE"
+    ];
+    
     for (var key in blocks) {
+        if (key in dictInstPV) {
+            continue
+        }
         if (key in dictLongerInstPVs) {
             var block = blocks[key];
-            var label = block["value"] == "" ? "N/A" : block["value"].slice(0,-1);
-            displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
+            if (block["value"] != "") {
+                var label = block["value"].slice(0, -1);
+                displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
+            }
         } else if (ignore_pvs.indexOf(key) >= 0) {
             // Do nothing
         } else {
@@ -419,17 +420,17 @@ function getDisplayBlocks(node, blocks, linkGraph) {
  */
 function getDisplayRunInfo(node, blocks){
     clear(node)
-    // Add all in order first
+
+    // Add variable parameters at the top of the list
+    getDisplayBlocks(node, blocks, false);
+
+    // Add the fixed parameters
     for (var key in dictInstPV) {
         if (key in blocks) {
             var block = blocks[key];
             displayOneBlock(node, block, getTitle(key), false);
-            delete blocks[key]
         }
     }
-
-    // Add any left over on to the end
-    getDisplayBlocks(node, blocks, false);
 }
 
 function writeStatus(nodeBlock, status_text) {

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -53,6 +53,9 @@ dictLongerInstPVs = {
     "BANNER:LEFT:LABEL"   : "BANNER:LEFT:VALUE",
 }
 
+instHiddenAlarms = {
+    "emu" : [dictInstPV.BEAMCURRENT, dictInstPV.TOTALUAMPS, dictInstPV.SIM_MODE]
+}
 
 /**
  * Gets the proper display title for a PV.
@@ -377,9 +380,13 @@ function displayOneBlock(node, block, blockName, linkGraph) {
         if (rc_enabled === "YES" && (rc_inrange === "YES" || rc_inrange === "NO")) {
             writeRangeInfo(nodeBlock, rc_inrange);
         }
-        // write alarm status if active
-        if (!alarm.startsWith("null") && alarm !== "") {
-            writeAlarmInfo(nodeBlock, alarm);
+        
+        // if instrument does not have alarms set to hidden for this block
+        if (typeof instHiddenAlarms[instrument] === "undefined" || !instHiddenAlarms[instrument].includes(blockName)) {
+            // write alarm status if active
+            if (!alarm.startsWith("null") && alarm !== "") {
+                writeAlarmInfo(nodeBlock, alarm);
+            }
         }
     }
     node.appendChild(nodeBlock);
@@ -398,8 +405,10 @@ function getDisplayBlocks(node, blocks, linkGraph) {
     for (var key in blocks) {
         if (key in dictLongerInstPVs) {
             var block = blocks[key];
-            var label = block["value"] == "" ? "N/A" : block["value"].slice(0,-1);
-            displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
+            if (block["value"] != "") {
+                var label = block["value"].slice(0, -1);
+                displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
+            }  
         } else if (ignore_pvs.indexOf(key) >= 0) {
             // Do nothing
         } else {

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -53,9 +53,6 @@ dictLongerInstPVs = {
     "BANNER:LEFT:LABEL"   : "BANNER:LEFT:VALUE",
 }
 
-instHiddenAlarms = {
-    "emu" : [dictInstPV.BEAMCURRENT, dictInstPV.TOTALUAMPS, dictInstPV.SIM_MODE]
-}
 
 /**
  * Gets the proper display title for a PV.
@@ -380,13 +377,9 @@ function displayOneBlock(node, block, blockName, linkGraph) {
         if (rc_enabled === "YES" && (rc_inrange === "YES" || rc_inrange === "NO")) {
             writeRangeInfo(nodeBlock, rc_inrange);
         }
-        
-        // if instrument does not have alarms set to hidden for this block
-        if (typeof instHiddenAlarms[instrument] === "undefined" || !instHiddenAlarms[instrument].includes(blockName)) {
-            // write alarm status if active
-            if (!alarm.startsWith("null") && alarm !== "") {
-                writeAlarmInfo(nodeBlock, alarm);
-            }
+        // write alarm status if active
+        if (!alarm.startsWith("null") && alarm !== "") {
+            writeAlarmInfo(nodeBlock, alarm);
         }
     }
     node.appendChild(nodeBlock);
@@ -405,10 +398,8 @@ function getDisplayBlocks(node, blocks, linkGraph) {
     for (var key in blocks) {
         if (key in dictLongerInstPVs) {
             var block = blocks[key];
-            if (block["value"] != "") {
-                var label = block["value"].slice(0, -1);
-                displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
-            }  
+            var label = block["value"] == "" ? "N/A" : block["value"].slice(0,-1);
+            displayOneBlock(node, blocks[dictLongerInstPVs[key]], label, linkGraph);
         } else if (ignore_pvs.indexOf(key) >= 0) {
             // Do nothing
         } else {

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -8,10 +8,15 @@ var instrumentState;
 var showHidden;
 var timeout = 4000;
 
-dictInstPV = {
+dictDisplayFirstInstPVs = {
     RUNSTATE: 'Run Status',
     RUNNUMBER: 'Run Number',
     _RBNUMBER: 'RB Number',
+    _USERNAME: 'User(s)',
+    TITLE: 'Title'
+}
+
+dictInstPV = {
     TITLEDISP: 'Show Title',
     STARTTIME: 'Start Time',
     RUNDURATION: 'Total Run Time',
@@ -55,6 +60,8 @@ dictLongerInstPVs = {
 function getTitle(title) {
     if (title in dictInstPV){
         return dictInstPV[title];
+    } else if (title in dictDisplayFirstInstPVs) {
+        return dictDisplayFirstInstPVs[title];
     }
     return title;
 }
@@ -388,7 +395,7 @@ function displayOneBlock(node, block, blockName, linkGraph) {
 function getDisplayBlocks(node, blocks, linkGraph) {
     ignore_pvs = [
         "1:1:VALUE", "2:1:VALUE", "3:1:VALUE", "1:2:VALUE", "2:2:VALUE", "3:2:VALUE", "BANNER:RIGHT:VALUE", "BANNER:LEFT:VALUE", "BANNER:MIDDLE:VALUE", 
-        "BEAMCURRENT", "PERIOD", "NUMPERIODS", "TOTALUAMPS", "MONITORCOUNTS", "SHUTTER", "_USERNAME", "TITLE"
+        "BEAMCURRENT", "PERIOD", "NUMPERIODS", "TOTALUAMPS", "MONITORCOUNTS", "SHUTTER", "RUNSTATE", "RUNNUMBER", "_RBNUMBER", "_USERNAME", "TITLE"
     ];
     
     for (var key in blocks) {
@@ -421,10 +428,18 @@ function getDisplayBlocks(node, blocks, linkGraph) {
 function getDisplayRunInfo(node, blocks){
     clear(node)
 
-    // Add variable parameters at the top of the list
+    // Add display-first fixed parameters to the top of the list
+    for (var key in dictDisplayFirstInstPVs) {
+        if (key in blocks) {
+            var block = blocks[key];
+            displayOneBlock(node, block, getTitle(key), false);
+        }
+    }
+
+    // Add variable parameters
     getDisplayBlocks(node, blocks, false);
 
-    // Add the fixed parameters
+    // Add the rest of the fixed parameters
     for (var key in dictInstPV) {
         if (key in blocks) {
             var block = blocks[key];


### PR DESCRIPTION
#### Description of work
Set `Beam current` (irrelevant for muons), `Total uamps` (irrelevant for muons) and `DAE simulation mode` to blocks with hidden alarms for EMU.
Blocks with no label ("N/A") will no longer be displayed, as they didn't seem to hold any values on other instruments either.

#### Ticket
https://github.com/ISISComputingGroup/IBEX/issues/5765

