### PR TITLE
Use https on separate ip

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /log/*.log
 /log/*.log.*
 JSON_bourne.log
-*.pyc
+*.py[co]
 test-reports/
 .idea/
+__pycache__/

--- a/front_end/Overview/ibexOverview.js
+++ b/front_end/Overview/ibexOverview.js
@@ -1,5 +1,5 @@
-var PORT = 60000;
-var HOST = "https://dataweb.isis.rl.ac.uk"
+var PORT = 443;
+var HOST = "https://dataweb2.isis.rl.ac.uk"
 
 var INST_REFRESH = 5000;
 var WALL_DISP_REFRESH = 2 * 60 * 1000;
@@ -104,7 +104,7 @@ function display_data(data){
 	var total_users = Object.keys(instruments).length;
 
 	//TODO use the instlist for this - https://github.com/ISISComputingGroup/IBEX/issues/7011
-	var TS2_instruments = ["LET", "POLREF", "NIMROD", "IMAT", "SANS2D", "LARMOR", "WISH", "INTER", "CHIPIR", "OFFSPEC", "ZOOM", "WISH_SETUP"]; 
+	var TS2_instruments = ["LET", "POLREF", "NIMROD", "IMAT", "SANS2D", "LARMOR", "WISH", "INTER", "CHIPIR", "OFFSPEC", "ZOOM", "WISH_SETUP"];
 	clearBox("TS1buttons")
 	clearBox("TS2buttons")
 	for (value in instruments){

--- a/front_end/default.html
+++ b/front_end/default.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01//EN"
-   "http://www.w3.org/TR/html4/strict.dtd">
+   "https://www.w3.org/TR/html4/strict.dtd">
 
 <html>
     <head>
@@ -52,7 +52,9 @@
             <tr>
                 <td>
                     <h6>This website is powered by the JSON Bourne Server &copy;</h6>
-					<a href="http://bugs.isis.rl.ac.uk/enter_bug.cgi?product=PC%20Instrument%20Control&format=pcinst">Submit a bug or problem</a>
+					<a href="https://sparrowhawk.nd.rl.ac.uk/footprints/?product=PC%20Instrument%20Control&format=pcinst">Submit a bug or problem</a>
+					<P><B>If a dashboard link does not work, please try clearing you browser cached files if you have not done so prior to 6 July 2023 (Settings -> privacy -> clear browsing data -> cached images and files)   </P>
+
                 </td>
             </tr>
         </table>

--- a/front_end/display_blocks.js
+++ b/front_end/display_blocks.js
@@ -1,5 +1,5 @@
-var PORT = 60000;
-var HOST = "https://dataweb.isis.rl.ac.uk"
+var PORT = 443;
+var HOST = "https://dataweb2.isis.rl.ac.uk";
 var DEFAULT_PV_VALUE = "UNKNOWN";
 
 var instrument = getURLParameter("Instrument");

--- a/webserver.py
+++ b/webserver.py
@@ -23,8 +23,8 @@ handler.setFormatter(logging.Formatter('%(asctime)s %(message)s'))
 logger.setLevel(logging.INFO)
 logger.addHandler(handler)
 
-HOST, PORT = '', 60000
-
+# use dataweb2.isis.rl.ac.uk / ndaextweb3-data.nd.rl.ac.uk (130.246.92.89)
+HOST, PORT = '130.246.92.89', 443
 
 class MyHandler(tornado.web.RequestHandler):
     """
@@ -93,10 +93,10 @@ if __name__ == '__main__':
             (r"/", MyHandler),
         ])
         http_server = tornado.httpserver.HTTPServer(application, ssl_options={
-            "certfile": r"C:\Users\ibexbuilder\dataweb_isis_rl_ac_uk.crt",
-            "keyfile": r"C:\Users\ibexbuilder\dataweb_isis_rl_ac_uk.key",
+            "certfile": r"C:\Users\ibexbuilder\dataweb2_isis_rl_ac_uk.crt",
+            "keyfile": r"C:\Users\ibexbuilder\dataweb2_isis_rl_ac_uk.key",
         })
-        http_server.listen(PORT)
+        http_server.listen(PORT, HOST)
         tornado.ioloop.IOLoop.current().start()
     except KeyboardInterrupt:
         print("Shutting down")


### PR DESCRIPTION
Use separate IP address for json bourne so both it and main web server can be on port 443. Resolves issues with connections from some guest networks that didn't like https over ports other than 443